### PR TITLE
fix: call Store with array to avoid Marten IEnumerable document type error

### DIFF
--- a/src/TwentyTwenty.DomainDriven.Marten/MartenEventPublishingRepository.cs
+++ b/src/TwentyTwenty.DomainDriven.Marten/MartenEventPublishingRepository.cs
@@ -37,7 +37,7 @@ namespace TwentyTwenty.DomainDriven.Marten
             // batched upserts touching the same rows in different orders can form a
             // lock cycle and trigger a PostgreSQL deadlock (SQLState 40P01).
             var ordered = aggregates.OrderBy(a => a.Id).ToList();
-            _database.Store(ordered);
+            _database.Store(ordered.ToArray());
             await _database.SaveChangesAsync(token);
             await PublishEvents(ordered, token);
         }

--- a/src/TwentyTwenty.DomainDriven.Marten/MartenEventPublishingRepository.cs
+++ b/src/TwentyTwenty.DomainDriven.Marten/MartenEventPublishingRepository.cs
@@ -36,8 +36,8 @@ namespace TwentyTwenty.DomainDriven.Marten
             // their row locks in the same order. Without a consistent order, two
             // batched upserts touching the same rows in different orders can form a
             // lock cycle and trigger a PostgreSQL deadlock (SQLState 40P01).
-            var ordered = aggregates.OrderBy(a => a.Id).ToList();
-            _database.Store(ordered.ToArray());
+            var ordered = aggregates.OrderBy(a => a.Id).ToArray();
+            _database.Store(ordered);
             await _database.SaveChangesAsync(token);
             await PublishEvents(ordered, token);
         }


### PR DESCRIPTION
## Problem

`_database.Store(ordered)` where `ordered` is `List<T>` causes Marten to resolve the overload as `Store<List<T>>(entity)` — treating the entire list as a single document. Marten then throws:

> Do not use IEnumerable<T> here as the document type. Either cast entities to an array instead or use the IEnumerable<T> Store() overload instead.

This was introduced in commit `5df687b8` (v3.28.1) when ordering aggregates by Id to prevent PostgreSQL deadlocks.

## Fix

Call `.ToArray()` before passing to `Store()` so C# resolves it to the correct `Store<T>(params T[])` overload.

## Impact

Production error in `TwentyTwenty.Messaging` — `CreateEmailCommandHandler` failing on every message.